### PR TITLE
Use bpf_probe_read_user{,_str}

### DIFF
--- a/bpf/rbperf.h
+++ b/bpf/rbperf.h
@@ -3,6 +3,14 @@
 // This source code is licensed under the MIT license found in the
 // LICENSE file in the root directory of this source tree.
 
+#if READ_USERSPACE_ADDRESS_SPACE
+#define rbperf_read bpf_probe_read_user
+#define rbperf_read_str bpf_probe_read_user_str
+#else
+#define rbperf_read bpf_probe_read
+#define rbperf_read_str bpf_probe_read_str
+#endif
+
 #ifdef USE_ABSOLUTE_PATH
 // TODO(javierhonduco): Add test for this
 #define PATH_TYPE_OFFSET 0x8  // ABSOLUTE_PATH_OFFSET

--- a/rbperf.py
+++ b/rbperf.py
@@ -12,7 +12,7 @@ from ctypes import Structure, c_ulonglong, c_ulong, c_uint, c_int
 import sys
 
 from proto import rbperf_pb2
-from utils import rb_thread_address, max_stacks_for_kernel
+from utils import rb_thread_address, max_stacks_for_kernel, read_userspace_address_space
 from version_specific_config import offsets_for_version, index_for_version
 
 
@@ -50,6 +50,7 @@ class RubyBPFStackWalker:
             cflags=[
                 f"-D__BPF_PROGRAMS_COUNT__={self.bpf_programs_count}",
                 f"-D__MAX_STACKS_PER_PROGRAM__={self.max_stacks_per_program}",
+                f"-DREAD_USERSPACE_ADDRESS_SPACE={int(read_userspace_address_space())}",
             ],
             usdt_contexts=self.usdt_contexts,
         )

--- a/utils.py
+++ b/utils.py
@@ -35,6 +35,15 @@ def max_stacks_for_kernel() -> int:
         return 15
 
 
+def read_userspace_address_space() -> bool:
+    """
+    Naive check to see if `read_userspace_address_space` & friends
+    are supported
+    """
+    major, minor = map(int, os.uname().release.split(".")[:2])
+    return (major, minor) >= (5, 4)
+
+
 def ruby_dynamic_linked(pid: int) -> Optional[Tuple[str, int]]:
     with open(f"/proc/{pid}/smaps", "rb") as smaps:
         for line in smaps.readlines():


### PR DESCRIPTION
This makes sure we are accessing the target Ruby process' address space
and not some bogus kernel address. `bpf_probe_read` is no longer the
recommended option either, but we'll keep using the previous helper for
compatibility with older kernels.

Has some very naive way to detect which memory access helper we should
use. Maybe we could implement some smarter checks at runtime with a
sample programs that attempt to use the newer features we are interested
in.