### PR TITLE
[tests] Improve naming of the test program's top frames

### DIFF
--- a/tests/ruby_programs/huge_stack.rb
+++ b/tests/ruby_programs/huge_stack.rb
@@ -1,8 +1,8 @@
-def infinite_loop
+def top
   File.open("/")
 end
 def a150
-	infinite_loop
+	top
 end
 def a149
 	a150

--- a/tests/ruby_programs/large_stack.rb
+++ b/tests/ruby_programs/large_stack.rb
@@ -1,9 +1,9 @@
-def infinite_loop
+def top
   File.open("/")
 end
 
 def a33
-    infinite_loop
+    top
 end
 def a32
 	a33

--- a/tests/ruby_programs/small_stack.rb
+++ b/tests/ruby_programs/small_stack.rb
@@ -1,9 +1,9 @@
-def infinite_loop
+def top
   File.open("/")
 end
 
 def c
-    infinite_loop
+    top
 end
 
 def b

--- a/tests/test_rbperf.py
+++ b/tests/test_rbperf.py
@@ -144,7 +144,7 @@ class TestStackWalker(unittest.TestCase):
         self.assertEqual(first_frame["method_name"], "<main>")
 
         self.assertEqual(last_frame["path"], "tests/ruby_programs/large_stack.rb")
-        self.assertEqual(last_frame["method_name"], "infinite_loop")
+        self.assertEqual(last_frame["method_name"], "top")
 
     def test_stack_too_large(self):
         self._generate_event(DEFAULT_RUBY_BINARY, "tests/ruby_programs/huge_stack.rb")
@@ -216,7 +216,7 @@ class TestStackWalker(unittest.TestCase):
         self.assertEqual(first_frame["method_name"], "<main>")
 
         self.assertEqual(last_frame["path"], "tests/ruby_programs/small_stack.rb")
-        self.assertEqual(last_frame["method_name"], "infinite_loop")
+        self.assertEqual(last_frame["method_name"], "top")
 
 
 class TestIncreasedTailCallsTestCase(unittest.TestCase):
@@ -252,7 +252,7 @@ class TestIncreasedTailCallsTestCase(unittest.TestCase):
         )
 
         self.assertEqual(last_frame["path"], "tests/ruby_programs/huge_stack.rb")
-        self.assertEqual(last_frame["method_name"], "infinite_loop")
+        self.assertEqual(last_frame["method_name"], "top")
 
     def _generate_event(self, version, testcase):
         p = spawn_test_ruby(version, testcase)


### PR DESCRIPTION
As this was written when we only had the CPU sampling mode, and we switched to the tracepoint tests as they are more deterministic & faster