### PR TITLE
Add placeholder for comm if decoding fails

### DIFF
--- a/rbperf.py
+++ b/rbperf.py
@@ -17,6 +17,7 @@ from utils import (
     max_stacks_for_kernel,
     read_userspace_address_space,
     process_exists,
+    safely_decode_bytes,
 )
 from version_specific_config import offsets_for_version, index_for_version
 
@@ -123,7 +124,9 @@ class RubyBPFStackWalker:
         event = self.queue.pop(0)
         stacktrace = {
             "timestamp": event.timestamp,
-            "comm": event.comm.decode(),
+            # TODO: When dealing with very high-frequency events, sometimes
+            # comm is garbled bytes. This needs more investigation.
+            "comm": safely_decode_bytes(event.comm, "[comm failed to fetch]"),
             "pid": event.pid,
             "stack_status": event.stack_status,
             "frames": [],

--- a/utils.py
+++ b/utils.py
@@ -136,3 +136,10 @@ def process_exists(pid: int) -> bool:
         return True
     except ProcessLookupError:
         return False
+
+
+def safely_decode_bytes(content: bytes, placeholder: str) -> str:
+    try:
+        return content.decode()
+    except UnicodeDecodeError:
+        return placeholder


### PR DESCRIPTION
Sometimes, while dealing with high-frequency events, comm is garbled.
This needs to be investigated but setting a band-aid for now.