### PR TITLE
Fix global symbol resolution

### DIFF
--- a/tests/test_rbperf.py
+++ b/tests/test_rbperf.py
@@ -9,11 +9,6 @@ import os
 import time
 import unittest
 
-# TODO(javierhonduco): Rethink vendorised bcc
-parent_dir = os.path.abspath(os.path.dirname(__file__))
-vendor_dir = os.path.join(parent_dir, "../vendor")
-sys.path.insert(0, vendor_dir)
-
 from rbperf import RbperfPerfEvent, RbperfTracepoint
 from utils import is_root
 


### PR DESCRIPTION
We were using BCC's `bcc_resolve_symname` which seemed to work fine on
both systems I had tried it.

The globals we are interested in (ruby version and the current thread
pointer) are sometimes placed in a non-executable memory area. I am not
sure if this is due to memory alignment, due to different libc versions,
or something completely different.

This is something that had been already reported upstream https://github.com/iovisor/bcc/pull/2441,
which was verified by running the reproducer under GDB and traced
execution [branching off in this failure
case](https://github.com/iovisor/bcc/blob/7e3f0c08c7c28757711c0a173b5bd7d9a31cf7ee/src/cc/bcc_syms.cc#L760).

This commit simply wraps `bcc_elf_foreach_sym` and uses it instead.

Thanks @SamSaffron for reporting this!

## Test Plan
```
[rbperf]$ sudo bin/test
..Profiling pid: 3822 (Ruby 2.6.3) with addr: 0x565219f8b240
.Profiling pid: 3823 (Ruby 2.6.3) with addr: 0x5582c140a240
.Profiling pid: 3824 (Ruby 2.6.3) with addr: 0x564af97cb240
Profiling pid: 3825 (Ruby 2.6.3) with addr: 0x5627a666d240
.Profiling pid: 3826 (Ruby 2.6.3) with addr: 0x5562e2187240
.Profiling pid: 3827 (Ruby 2.6.3) with addr: 0x555a52d74240
Profiling pid: 3828 (Ruby 2.6.6) with addr: 0x560c0583a240
Profiling pid: 3829 (Ruby 2.7.1) with addr: 0x5610d4aedba0
.Profiling pid: 3830 (Ruby 2.4.4) with addr: 0x55954faf4630
.Profiling pid: 3832 (Ruby 2.4.4) with addr: 0x55ed4a990630
.Profiling pid: 3834 (Ruby 2.6.3) with addr: 0x55be42312240
.Profiling pid: 3835 (Ruby 2.6.3) with addr: 0x55fe3c124240
.Profiling pid: 3836 (Ruby 2.4.4) with addr: 0x55a62f361630
Profiling pid: 3838 (Ruby 2.4.4) with addr: 0x55829038b630
Profiling pid: 3840 (Ruby 2.5.7) with addr: 0x5569bc7f7b00
Profiling pid: 3842 (Ruby 2.5.8) with addr: 0x55a3c4193b00
Profiling pid: 3844 (Ruby 2.6.3) with addr: 0x560a3fdf4240
Profiling pid: 3845 (Ruby 2.6.6) with addr: 0x55eb77e2d240
Profiling pid: 3846 (Ruby 2.7.1) with addr: 0x556ce29f6ba0
.........
----------------------------------------------------------------------
Ran 20 tests in 5.799s

OK
```