### PR TITLE
Fix stdout reporter and rename it to readable

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -22,7 +22,7 @@ from rbperf import (
 from handlers import CompactHandler
 from storage import CompactProtobufReader
 from utils import is_root
-from reporters import stdout_reporter, flamegraph_reporter, folded_reporter
+from reporters import readable_reporter, flamegraph_reporter, folded_reporter
 
 
 EVERY_MILLION_EVENTS = 10 ** 6
@@ -61,7 +61,10 @@ def arg_parser():
     parser_report.add_argument("--input", type=str, required=True)
     parser_report.add_argument("--output", type=str, required=True)
     parser_report.add_argument(
-        "--format", type=str, required=True, choices=("flamegraph", "folded", "stdout")
+        "--format",
+        type=str,
+        required=True,
+        choices=("flamegraph", "folded", "readable"),
     )
     return parser
 
@@ -154,8 +157,8 @@ def main():
         with open(input_file_path, "rb") as input_file:
             proto = CompactProtobufReader(input_file)
 
-            if output_format == "stdout":
-                stdout_reporter(proto)
+            if output_format == "readable":
+                readable_reporter(proto, output_file_path)
             elif output_format == "flamegraph":
                 flamegraph_reporter(proto, output_file_path)
             elif output_format == "folded":

--- a/reporters.py
+++ b/reporters.py
@@ -9,15 +9,18 @@ import io
 import pkg_resources
 
 
-def stdout_reporter(proto) -> None:
-    for stack in proto.read_stacks():
-        pid = stack.pid
-        comm = stack.comm
-        if stack.stack_status == 1:
-            print("_warning_: this stack might be incomplete")
-        for frame in stack.frames:
-            print(f"[{comm}][{pid}] {frame.path}:{frame.lineno} `{frame.method}`")
-        print()
+def readable_reporter(proto, output_file_path: str) -> None:
+    with open(output_file_path, "w") as output:
+        for stack in proto.read_stacks():
+            pid = stack.pid
+            comm = stack.comm
+            if stack.stack_status == 1:
+                output.write("_warning_: this stack might be incomplete\n")
+            for frame in stack.frames:
+                output.write(
+                    f"[{comm}][{pid}] {frame.path}:{frame.lineno} `{frame.method}`\n"
+                )
+            output.write("\n")
 
 
 def flamegraph_reporter(proto, output_file_path: str) -> None:
@@ -38,7 +41,9 @@ def flamegraph_reporter(proto, output_file_path: str) -> None:
 
     flamegraph_path = pkg_resources.resource_filename("rbperf", "vendor/flamegraph.pl")
     p = subprocess.Popen(
-        [flamegraph_path, "--inverted"], stdin=subprocess.PIPE, stdout=subprocess.PIPE,
+        [flamegraph_path, "--inverted"],
+        stdin=subprocess.PIPE,
+        stdout=subprocess.PIPE,
     )
     flamegraph_html = p.communicate(input=f.getvalue().encode())[0].decode()
 


### PR DESCRIPTION
It was just printing to stdout but we were forcing the user to specify
an output which really does not make sense.

Very useful for debugging with:

```
sudo bin/rbperf report --input=$DATA --format=readable --output=/dev/stdout
```