### PR TITLE
Bump default Ruby version to 2.7.1

### DIFF
--- a/tests/test_rbperf.py
+++ b/tests/test_rbperf.py
@@ -20,7 +20,7 @@ if not is_root():
 # Unfortunately CI's Kernel does not support 1M instructions
 MAX_STACKS = 15
 
-DEFAULT_RUBY_BINARY = "ruby-2.6.3"
+DEFAULT_RUBY_BINARY = "ruby-2.7.1"
 EVERY_MILLION_EVENTS = 10 ** 6
 
 


### PR DESCRIPTION
as it's the latest we support

```
[rbperf]$ sudo bin/test
..Profiling pid: 2996 (Ruby 2.7.1) with addr: 0x55f790e7fba0
.Profiling pid: 2998 (Ruby 2.7.1) with addr: 0x56249d79cba0
.Profiling pid: 2999 (Ruby 2.7.1) with addr: 0x55d7fc537ba0
Profiling pid: 3000 (Ruby 2.7.1) with addr: 0x55b2de913ba0
.Profiling pid: 3001 (Ruby 2.7.1) with addr: 0x55dd77730ba0
.Profiling pid: 3002 (Ruby 2.6.3) with addr: 0x56403d46c240
Profiling pid: 3003 (Ruby 2.6.6) with addr: 0x55b8abb63240
Profiling pid: 3004 (Ruby 2.7.1) with addr: 0x55b1d2f7dba0
.Profiling pid: 3005 (Ruby 2.4.4) with addr: 0x55996a8cc630
.Profiling pid: 3007 (Ruby 2.4.4) with addr: 0x5639560de630
.Profiling pid: 3009 (Ruby 2.7.1) with addr: 0x55993b739ba0
.Profiling pid: 3010 (Ruby 2.7.1) with addr: 0x55d1145b3ba0
.Profiling pid: 3011 (Ruby 2.4.4) with addr: 0x56394377d630
Profiling pid: 3013 (Ruby 2.4.4) with addr: 0x55fd86db1630
Profiling pid: 3015 (Ruby 2.5.7) with addr: 0x561b1ae25b00
Profiling pid: 3017 (Ruby 2.5.8) with addr: 0x562803d9eb00
Profiling pid: 3019 (Ruby 2.6.3) with addr: 0x55ccde8cd240
Profiling pid: 3020 (Ruby 2.6.6) with addr: 0x55a2093b7240
Profiling pid: 3021 (Ruby 2.7.1) with addr: 0x5574b18c1ba0
.........
----------------------------------------------------------------------
Ran 20 tests in 6.055s

OK
```